### PR TITLE
Feature(Implement JSON storage for sharefiles)

### DIFF
--- a/templates/listshares.html
+++ b/templates/listshares.html
@@ -69,13 +69,13 @@
                                     {{ range $content := .List }}
                                         <tr>
 						<td class="type">
-              <input id="checkBox" type="checkbox" name='{{ $content.File }}'>
+              <input id="checkBox" type="checkbox" name='{{ $content.Name }}'>
               <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
             </td>
-						<td><a href={{ $content.Url }}>{{ $content.Name }}</a></td>
-						<td class="hidden-xs hidden-sm"><a href="{{ $content.Url }}">{{ $content.Url }}</a></td>
+						<td><a href={{ $content.ShareUrl }}>{{ $content.File }}</a></td>
+						<td class="hidden-xs hidden-sm"><a href="{{ $content.ShareUrl }}">{{ $content.ShareUrl }}</a></td>
 						<td class="hidden-xs hidden-sm delete">
-                                                    <a href="javascript:void(0)" onclick="DelShare('{{$content.File}}')" role="button" class="btn btn-raised btn-danger btn-xs">Delete</a>
+                                                    <a href="javascript:void(0)" onclick="DelShare('{{$content.Name}}')" role="button" class="btn btn-raised btn-danger btn-xs">Delete</a>
                                                 </td>
 					</tr>
                                     {{end}}

--- a/templates/share.html
+++ b/templates/share.html
@@ -46,9 +46,9 @@
 	</nav>
 	<div class="container" id="content">
 	<div class="panel panel-primary">
-		<div class="panel-heading">{{ .Name }}</div>
+		<div class="panel-heading">{{ .File }}</div>
 		<div class="panel-body">
-                    <a href="{{ .Url }}" role="button" class="btn btn-raised btn-success center-block">Download</a>
+                    <a href="{{ .GetUrl }}" role="button" class="btn btn-raised btn-success center-block">Download</a>
 		</div>
 	</div>
 	</div>


### PR DESCRIPTION
It implement JSON storage for sharefiles
It will be usefull for the others features in https://github.com/xataz/gobrowser/issues/5

It will surely broke old shares so there are 3 solutions.

*   Implement a legacy method in case we not have JSON and make the same steps as before.
*   Make another utility to convert old sharefile in new format
*   Let the user know what they need to remove the old sharefile and make them again